### PR TITLE
Fixes assert on policy update status changes

### DIFF
--- a/src/components/policy/src/policy/src/update_status_manager.cc
+++ b/src/components/policy/src/policy/src/update_status_manager.cc
@@ -242,6 +242,7 @@ void UpdateStatusManager::UpdateThreadDelegate::threadMain() {
           termination_condition_.WaitFor(auto_lock, timeout_);
       if (sync_primitives::ConditionalVariable::kTimeout == wait_status) {
         if (update_status_manager_) {
+          sync_primitives::AutoUnlock auto_unlock(auto_lock);
           update_status_manager_->OnUpdateTimeoutOccurs();
         }
       }


### PR DESCRIPTION
Due to changing internal mutex to non-recursive there was a problem with
double lock on the same mutex. Fixed by avoiding of double lock.
