### PR TITLE
Make google test buildable on Windows

### DIFF
--- a/src/3rd_party-static/gmock-1.7.0/gtest/cmake/internal_utils.cmake
+++ b/src/3rd_party-static/gmock-1.7.0/gtest/cmake/internal_utils.cmake
@@ -24,16 +24,18 @@ macro(fix_default_compiler_settings_)
     foreach (flag_var
              CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
              CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
-      if (NOT BUILD_SHARED_LIBS AND NOT gtest_force_shared_crt)
-        # When Google Test is built as a shared library, it should also use
-        # shared runtime libraries.  Otherwise, it may end up with multiple
-        # copies of runtime library data in different modules, resulting in
-        # hard-to-find crashes. When it is built as a static library, it is
-        # preferable to use CRT as static libraries, as we don't have to rely
-        # on CRT DLLs being available. CMake always defaults to using shared
-        # CRT libraries, so we override that default here.
-        string(REPLACE "/MD" "-MT" ${flag_var} "${${flag_var}}")
-      endif()
+      # When Google Test is built as a shared library, it should also use
+      # shared runtime libraries.  Otherwise, it may end up with multiple
+      # copies of runtime library data in different modules, resulting in
+      # hard-to-find crashes. When it is built as a static library, it is
+      # preferable to use CRT as static libraries, as we don't have to rely
+      # on CRT DLLs being available. CMake always defaults to using shared
+      # CRT libraries, so we override that default here.
+	  
+      # ANosach: /MD flag should be enabled for SDL build
+      # if (NOT BUILD_SHARED_LIBS AND NOT gtest_force_shared_crt)
+        # string(REPLACE "/MD" "-MT" ${flag_var} "${${flag_var}}")
+      # endif()
 
       # We prefer more strict warning checking for building Google Test.
       # Replaces /W3 with /W4 in defaults.

--- a/src/3rd_party-static/gmock-1.7.0/include/gmock/gmock-spec-builders.h
+++ b/src/3rd_party-static/gmock-1.7.0/include/gmock/gmock-spec-builders.h
@@ -62,6 +62,8 @@
 
 #if defined(OS_POSIX)
 #include <sys/time.h>
+#elif defined(OS_WINDOWS)
+#include <winsock2.h>
 #endif
 
 #include <map>


### PR DESCRIPTION
We extended `gmock` with custom functionality using `timeval` struct and operations with it. This way is not crossplatform and requires changes for Windows. That's it.

@OHerasym, @dev-gh please review
