### PR TITLE
Add winhdr.h file to gmock

### DIFF
--- a/src/3rd_party-static/gmock-1.7.0/include/gmock/gmock-spec-builders.h
+++ b/src/3rd_party-static/gmock-1.7.0/include/gmock/gmock-spec-builders.h
@@ -63,7 +63,7 @@
 #if defined(OS_POSIX)
 #include <sys/time.h>
 #elif defined(OS_WINDOWS)
-#include <winsock2.h>
+#include "winhdr.h"
 #endif
 
 #include <map>

--- a/src/3rd_party-static/gmock-1.7.0/include/gmock/winhdr.h
+++ b/src/3rd_party-static/gmock-1.7.0/include/gmock/winhdr.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef GMOCK_INCLUDE_GMOCK_WINHDR_H_
+#define GMOCK_INCLUDE_GMOCK_WINHDR_H_
+
+#include <winsock2.h>
+
+#ifdef min
+#undef min
+#endif
+
+#ifdef max
+#undef max
+#endif
+
+#ifdef CreateFile
+#undef CreateFile
+#endif
+
+#ifdef DeleteFile
+#undef DeleteFile
+#endif
+
+#ifdef CreateDirectory
+#undef CreateDirectory
+#endif
+
+#ifdef RemoveDirectory
+#undef RemoveDirectory
+#endif
+
+#ifdef CopyFile
+#undef CopyFile
+#endif
+
+#ifdef MoveFile
+#undef MoveFile
+#endif
+
+#ifdef ERROR
+#undef ERROR
+#endif
+
+#endif  // GMOCK_INCLUDE_GMOCK_WINHDR_H_


### PR DESCRIPTION
We cannot include windows headers directly from gmock sources because of definitions conflicts,
so this PR adds `winhdr.h` file with undefinitions like in SDL.

@OHerasym please review
