### PR TITLE
Reduce smart object test running time

### DIFF
--- a/src/components/smart_objects/test/SmartObjectStress_test.cc
+++ b/src/components/smart_objects/test/SmartObjectStress_test.cc
@@ -127,7 +127,7 @@ class StressTestHelper : public ::testing::Test {
       }
       case 2:  // double
       {
-        double dVal = 100.0 / (rand() % 200);
+        double dVal = 100.0 / (rand() % 100);
         obj = dVal;
         mVerifyMap[key_path] = to_string(dVal);
         // std::cout << "Created double, value: " << dVal << std::endl;
@@ -143,7 +143,7 @@ class StressTestHelper : public ::testing::Test {
       }
       case 4:  // string
       {
-        std::string strVal(rand() % 200, get_random_char());
+        std::string strVal(rand() % 100, get_random_char());
         obj = strVal;  // string with random char filled random size
         mVerifyMap[key_path] = strVal;
         // std::cout << "Created string, value: " << strVal << std::endl;
@@ -180,7 +180,7 @@ class StressTestHelper : public ::testing::Test {
         }
         break;
       case 7:  // binary
-        int dataSize = rand() % 200;
+        int dataSize = rand() % 100;
         char randomChar = get_random_char();
         std::string strDataVal(dataSize, randomChar);
         std::string strVal("c:");
@@ -241,7 +241,7 @@ class StressTestHelper : public ::testing::Test {
 TEST_F(StressTestHelper, StressTest) {
   SmartObject objects;
 
-  const int size = 11;
+  const int size = 5;
 
   for (int i = 0; i < size; i++) {
     SmartObject obj;


### PR DESCRIPTION
Running time of `StressTest` has been reduced from ~80000 to ~20 ms
@OHerasym, @dev-gh please review
