### PR TITLE
Use platform-independent uint64_t type for thread ID on all platforms

### DIFF
--- a/src/3rd_party-static/MessageBroker/include/system.h
+++ b/src/3rd_party-static/MessageBroker/include/system.h
@@ -191,14 +191,7 @@ namespace System
        */
       bool Join(void** ret = NULL);
 
-#ifdef _WIN32
-      HANDLE
-#else
-      pthread_t
-#endif
-      GetId() const {
-        return m_id;
-      }
+      uint64_t GetId() const;
 
     private:
       /**

--- a/src/3rd_party-static/MessageBroker/src/lib_messagebroker/system.cpp
+++ b/src/3rd_party-static/MessageBroker/src/lib_messagebroker/system.cpp
@@ -24,6 +24,7 @@
 
 #include <time.h>
 #include <signal.h>
+#include <cstdint>
 
 #include "system.h"
 
@@ -89,6 +90,10 @@ bool Thread::Stop() {
 
 bool Thread::Join(void** ret) {
   return pthread_join(m_id, ret) == 0;
+}
+
+uint64_t Thread::GetId() const {
+  return static_cast<uint64_t>(m_id);
 }
 
 void* Thread::Call(void* arg) {
@@ -219,6 +224,10 @@ bool Thread::Join(void** ret) {
   m_id = NULL;
   *ret = (void*)val;
   return true;
+}
+
+uint64_t Thread::GetId() const {
+  return static_cast<uint64_t>(GetThreadId(m_id));
 }
 
 DWORD WINAPI Thread::Call(LPVOID arg) {

--- a/src/components/include/utils/threads/thread.h
+++ b/src/components/include/utils/threads/thread.h
@@ -156,11 +156,10 @@ class Thread {
   static void yield();
 
   // Get unique ID of currently executing thread
-  static PlatformThreadHandle CurrentId();
+  static uint64_t CurrentId();
 
   // Give thread thread_id a name, helpful for debugging
-  static void SetNameForId(const PlatformThreadHandle& thread_id,
-                           std::string name);
+  static void SetNameForId(uint64_t thread_id, std::string name);
 
   /**
    * @brief Signals the thread to exit and returns once the thread has exited.

--- a/src/components/utils/include/utils/back_trace.h
+++ b/src/components/utils/include/utils/back_trace.h
@@ -61,10 +61,10 @@ class Backtrace {
 
   // Captured symbols in order from topmost stack frame to last captured
   std::vector<std::string> CallStack() const;
-  threads::PlatformThreadHandle ThreadId() const;
+  uint64_t ThreadId() const;
 
  private:
-  threads::PlatformThreadHandle thread_id_;
+  uint64_t thread_id_;
   std::vector<void*> backtrace_;
 };
 

--- a/src/components/utils/include/utils/threads/thread_validator.h
+++ b/src/components/utils/include/utils/threads/thread_validator.h
@@ -67,10 +67,10 @@ class SingleThreadSimpleValidator {
   // This method should be called in every public method
   // of classes being checked for absence of concurrent access
   void AssertRunningOnCreationThread() const;
-  PlatformThreadHandle creation_thread_id() const;
+  uint64_t creation_thread_id() const;
 
  private:
-  const PlatformThreadHandle creation_thread_id_;
+  const uint64_t creation_thread_id_;
 };
 
 /*
@@ -92,14 +92,14 @@ class SingleThreadValidator {
 
   // Must be called prior to transferring object being validated to
   // another thread or when passing it back
-  void PassToThread(PlatformThreadHandle thread_id) const;
+  void PassToThread(uint64_t thread_id) const;
   // This method should be called in every public method
   // of classes being checked for absence of unintended concurrent
   // access
   void AssertRunningOnValidThread() const;
 
  private:
-  mutable PlatformThreadHandle owning_thread_id_;
+  mutable uint64_t owning_thread_id_;
 };
 
 }  // namespace threads

--- a/src/components/utils/src/back_trace.cc
+++ b/src/components/utils/src/back_trace.cc
@@ -89,7 +89,7 @@ vector<string> Backtrace::CallStack() const {
   return callstack;
 }
 
-threads::PlatformThreadHandle Backtrace::ThreadId() const {
+uint64_t Backtrace::ThreadId() const {
   return thread_id_;
 }
 

--- a/src/components/utils/src/threads/posix_thread.cc
+++ b/src/components/utils/src/threads/posix_thread.cc
@@ -133,11 +133,11 @@ void* Thread::threadFunc(void* arg) {
   return NULL;
 }
 
-void Thread::SetNameForId(const PlatformThreadHandle& thread_id,
-                          std::string name) {
+void Thread::SetNameForId(uint64_t thread_id, std::string name) {
   if (name.size() > THREAD_NAME_SIZE)
     name.erase(THREAD_NAME_SIZE);
-  const int rc = pthread_setname_np(thread_id, name.c_str());
+  const int rc =
+      pthread_setname_np(static_cast<pthread_t>(thread_id), name.c_str());
   if (rc != EOK) {
     LOGGER_WARN(logger_,
                 "Couldn't set pthread name \"" << name << "\", error code "
@@ -160,12 +160,12 @@ bool Thread::start() {
   return start(thread_options_);
 }
 
-PlatformThreadHandle Thread::CurrentId() {
-  return pthread_self();
+uint64_t Thread::CurrentId() {
+  return static_cast<uint64_t>(pthread_self());
 }
 
 bool Thread::IsCurrentThread() const {
-  return pthread_equal(CurrentId(), thread_handle());
+  return pthread_equal(static_cast<pthread_t>(CurrentId()), thread_handle());
 }
 
 bool Thread::start(const ThreadOptions& options) {

--- a/src/components/utils/src/threads/thread_delegate_posix.cc
+++ b/src/components/utils/src/threads/thread_delegate_posix.cc
@@ -46,7 +46,7 @@ ThreadDelegate::~ThreadDelegate() {
 
 void ThreadDelegate::exitThreadMain() {
   if (thread_) {
-    if (thread_->thread_handle() == pthread_self()) {
+    if (thread_->IsCurrentThread()) {
       pthread_exit(NULL);
     } else {
       pthread_cancel(thread_->thread_handle());

--- a/src/components/utils/src/threads/thread_delegate_qt.cc
+++ b/src/components/utils/src/threads/thread_delegate_qt.cc
@@ -44,7 +44,7 @@ ThreadDelegate::~ThreadDelegate() {
 
 void ThreadDelegate::exitThreadMain() {
   if (thread_) {
-    if (thread_->thread_handle() == QThread::currentThreadId()) {
+    if (thread_->IsCurrentThread()) {
       DCHECK(!"Cannot terminate self");
     } else {
       emit TerminateThread();

--- a/src/components/utils/src/threads/thread_delegate_win.cc
+++ b/src/components/utils/src/threads/thread_delegate_win.cc
@@ -44,7 +44,7 @@ ThreadDelegate::~ThreadDelegate() {
 
 void ThreadDelegate::exitThreadMain() {
   if (thread_) {
-    if (thread_->thread_handle() == GetCurrentThread()) {
+    if (thread_->IsCurrentThread()) {
       ExitThread(kThreadCancelledExitCode);
     } else {
       TerminateThread(thread_->thread_handle(), kThreadCancelledExitCode);

--- a/src/components/utils/src/threads/thread_qt.cc
+++ b/src/components/utils/src/threads/thread_qt.cc
@@ -92,8 +92,7 @@ void* Thread::threadFunc(void* arg) {
   return NULL;
 }
 
-void Thread::SetNameForId(const PlatformThreadHandle& thread_id,
-                          std::string name) {}
+void Thread::SetNameForId(uint64_t thread_id, std::string name) {}
 
 Thread::Thread(const char* name, ThreadDelegate* delegate, QObject* parent)
     : QObject(parent)
@@ -113,7 +112,7 @@ bool Thread::start() {
   return true;
 }
 
-PlatformThreadHandle Thread::CurrentId() {
+uint64_t Thread::CurrentId() {
   return QThread::currentThread();
 }
 

--- a/src/components/utils/src/threads/thread_validator.cc
+++ b/src/components/utils/src/threads/thread_validator.cc
@@ -44,7 +44,7 @@ SingleThreadSimpleValidator::SingleThreadSimpleValidator()
 SingleThreadSimpleValidator::~SingleThreadSimpleValidator() {}
 
 void SingleThreadSimpleValidator::AssertRunningOnCreationThread() const {
-  PlatformThreadHandle current_id = Thread::CurrentId();
+  uint64_t current_id = Thread::CurrentId();
   if (creation_thread_id_ != current_id) {
     LOGGER_ERROR(logger_,
                  "Single-threaded object created at thread "
@@ -53,7 +53,7 @@ void SingleThreadSimpleValidator::AssertRunningOnCreationThread() const {
   }
 }
 
-PlatformThreadHandle SingleThreadSimpleValidator::creation_thread_id() const {
+uint64_t SingleThreadSimpleValidator::creation_thread_id() const {
   return creation_thread_id_;
 }
 
@@ -62,12 +62,12 @@ SingleThreadValidator::SingleThreadValidator()
 
 SingleThreadValidator::~SingleThreadValidator() {}
 
-void SingleThreadValidator::PassToThread(PlatformThreadHandle thread_id) const {
+void SingleThreadValidator::PassToThread(uint64_t thread_id) const {
   owning_thread_id_ = thread_id;
 }
 
 void SingleThreadValidator::AssertRunningOnValidThread() const {
-  PlatformThreadHandle current_id = Thread::CurrentId();
+  uint64_t current_id = Thread::CurrentId();
   if (owning_thread_id_ != current_id) {
     LOGGER_ERROR(logger_,
                  "Single-threaded object owned by thread "

--- a/src/components/utils/src/threads/win_thread.cc
+++ b/src/components/utils/src/threads/win_thread.cc
@@ -115,8 +115,7 @@ void* Thread::threadFunc(void* arg) {
   return NULL;
 }
 
-void Thread::SetNameForId(const PlatformThreadHandle& thread_id,
-                          std::string name) {}
+void Thread::SetNameForId(uint64_t thread_id, std::string name) {}
 
 Thread::Thread(const char* name, ThreadDelegate* delegate)
     : name_(name ? name : "undefined")
@@ -132,12 +131,12 @@ bool Thread::start() {
   return start(thread_options_);
 }
 
-PlatformThreadHandle Thread::CurrentId() {
-  return GetCurrentThread();
+uint64_t Thread::CurrentId() {
+  return static_cast<uint64_t>(GetCurrentThreadId());
 }
 
 bool Thread::IsCurrentThread() const {
-  return CurrentId() == thread_handle();
+  return CurrentId() == static_cast<uint64_t>(GetThreadId(thread_handle()));
 }
 
 bool Thread::start(const ThreadOptions& options) {

--- a/src/components/utils/test/posix_thread_test.cc
+++ b/src/components/utils/test/posix_thread_test.cc
@@ -263,8 +263,8 @@ TEST(PosixThreadTest, StartThread_ExpectThreadStarted) {
 
 TEST(PosixThreadTest, StartOneThreadTwice_ExpectTheSameThreadStartedTwice) {
   // Arrange
-  PlatformThreadHandle thread1_id;
-  PlatformThreadHandle thread2_id;
+  uint64_t thread1_id;
+  uint64_t thread2_id;
   threads::Thread* thread = NULL;
   TestThreadDelegate* threadDelegate = new TestThreadDelegate();
   AutoLock test_lock(test_mutex_);
@@ -290,8 +290,8 @@ TEST(PosixThreadTest, StartOneThreadTwice_ExpectTheSameThreadStartedTwice) {
 TEST(PosixThreadTest,
      StartOneThreadAgainAfterRename_ExpectRenamedThreadStarted) {
   // Arrange
-  PlatformThreadHandle thread1_id;
-  PlatformThreadHandle thread2_id;
+  uint64_t thread1_id;
+  uint64_t thread2_id;
   threads::Thread* thread = NULL;
   TestThreadDelegate* threadDelegate = new TestThreadDelegate();
   AutoLock test_lock(test_mutex_);


### PR DESCRIPTION
On windows and Qt platform we cannot use `HANDLE` for threads comparison so we need to use `DWORD` thread ID for these purposes. To make `CurrentId` interface in `Thread` platform-independent it has been changed to return `uint64_t` value instead of platform specific `HANDLE` or `pthread_t`.

@dev-gh, @OHerasym please review
